### PR TITLE
Address license handling

### DIFF
--- a/.github/workflows/sync-headers.yml
+++ b/.github/workflows/sync-headers.yml
@@ -69,22 +69,53 @@ jobs:
           report_format: 'SPDX_JSON'
           scan_dir: src/pgm_build_dependencies/eigen/
 
-      - name: List fossology output
-        if: always()
-        run: |
-          echo "=== Current directory contents ==="
-          ls -la
-          echo "=== Looking for result directories ==="
-          find . -name "*result*" -type d
-          echo "=== Looking for output files ==="
-          find . -name "*.json" -o -name "*spdx*" -o -name "*SPDX*"
-
       - name: Upload Scan Results Artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: license-scan-results
           path: results/
+
+      - name: Remove files with non-accepted license
+        run: |          
+          # Install jq for JSON parsing
+          sudo apt-get update && sudo apt-get install -y jq
+          
+          # Find the SPDX JSON file
+          SPDX_FILE=$(find . -name "*spdx*.json" | head -1)
+          if [ -z "$SPDX_FILE" ]; then
+            echo "No SPDX JSON file found!"
+            exit 1
+          fi
+          echo "Found SPDX file: $SPDX_FILE"
+          
+          # Get files with GPL in their licenses
+          BAD_FILES=$(jq -r '
+            .files[] | 
+            select(.licenseInfoInFiles[]? | type == "string" and test("GPL"; "i")) | 
+            .fileName
+          ' "$SPDX_FILE")
+          
+          if [ -z "$BAD_FILES" ]; then
+            echo "No badly licensed files found - nothing to delete!"
+          else
+            echo "Badly licensed files found:"
+            echo "$BAD_FILES" | while read -r file_name; do
+              if [ -n "$file_name" ]; then
+                echo " - $file_name"
+                
+                # Construct full path and delete
+                full_path="src/pgm_build_dependencies/eigen/$file_name"
+                if [ -f "$full_path" ]; then
+                  rm -f "$full_path"
+                  echo "Deleted: $full_path"
+                else
+                  echo "File not found: $full_path"
+                fi
+              fi
+            done
+          fi
+        continue-on-error: true
 
       - name: build wheel
         run: |

--- a/.github/workflows/sync-headers.yml
+++ b/.github/workflows/sync-headers.yml
@@ -136,7 +136,14 @@ jobs:
           ls dist/
           echo "VERSION=v$(date +'%Y.%m.%d')" >> $GITHUB_ENV
 
+      - name: Debug workflow trigger
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "Force publish input: ${{ inputs.force_publish }}"
+          echo "Will commit on schedule or when force_publish is true: ${{ github.event_name == 'schedule' || inputs.force_publish }}"
+
       - name: Commit and push changes
+        if: ${{ github.event_name == 'schedule' || inputs.force_publish }}
         id: commit
         uses: stefanzweifel/git-auto-commit-action@v6
         with:
@@ -147,7 +154,7 @@ jobs:
           commit_author: GitHub Actions Bot <actions@github.com>
 
       - name: publish
-        if: ${{ inputs.force_publish || steps.commit.outputs.changes_detected == 'true'  }}
+        if: ${{ inputs.force_publish || (steps.commit.outputs.changes_detected == 'true' && github.event_name == 'schedule') }}
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.VERSION }}

--- a/.github/workflows/sync-headers.yml
+++ b/.github/workflows/sync-headers.yml
@@ -61,6 +61,20 @@ jobs:
           ls src/pgm_build_dependencies/eigen/
           ls src/pgm_build_dependencies/msgpack_cxx/
 
+      - name: License scan - eigen headers
+        uses: fossology/fossology-action@v1
+        with:
+          scan_mode: repo
+          scanners: 'nomos ojo copyright keyword'
+          report_format: 'SPDX_JSON'
+          scan_dir: src/pgm_build_dependencies/eigen/
+
+      - name: Upload Scan Results Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Fossology scan results
+          path: results/
+
       - name: build wheel
         run: |
           python -m build --wheel --outdir dist

--- a/.github/workflows/sync-headers.yml
+++ b/.github/workflows/sync-headers.yml
@@ -63,23 +63,19 @@ jobs:
 
       - name: License scan - eigen headers
         uses: fossology/fossology-action@v1
+        continue-on-error: true
         with:
           scan_mode: scan-dir
           scanners: 'nomos ojo'
           report_format: 'SPDX_JSON'
           scan_dir: src/pgm_build_dependencies/eigen/
 
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
       - name: Remove files with non-accepted license
         id: license-cleanup
-        if: always()
         run: |          
-          # Install jq for JSON parsing
-          sudo apt-get update && sudo apt-get install -y jq
-          
-          echo "=== Looking for SPDX files ==="
-          ls -la
-          find . -name "*.json" -type f
-          
           # Find the SPDX JSON file
           SPDX_FILE=$(find . -name "*spdx*.json" -o -name "sbom*.json" -o -name "*sbom.json"| head -1)
           
@@ -87,12 +83,11 @@ jobs:
             echo "No SPDX JSON file found! Fossology scan may have failed."
             echo "Available files:"
             find . -name "*.json" || echo "No JSON files found"
-            echo "Skipping license cleanup step."
-            exit 0
+            exit 1
           fi
           echo "Found SPDX file: $SPDX_FILE"
           
-          # Get files with GPL in their licenses
+          # Get badly licensed files
           BAD_FILES=$(jq -r '
             .files[] | 
             select(.licenseInfoInFiles[]? | type == "string" and test("GPL"; "i")) | 
@@ -121,7 +116,6 @@ jobs:
         continue-on-error: true
 
       - name: Check license cleanup status
-        if: always()
         run: |
           if [ "${{ steps.license-cleanup.outcome }}" = "failure" ]; then
             echo "WARNING: License cleanup step failed!"
@@ -131,21 +125,18 @@ jobs:
           fi
 
       - name: Upload Scan Results Artifact
-        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: license-scan-results
           path: results/
 
       - name: build wheel
-        if: always()
         run: |
           python -m build --wheel --outdir dist
           ls dist/
           echo "VERSION=v$(date +'%Y.%m.%d')" >> $GITHUB_ENV
 
       - name: Commit and push changes
-        if: always()
         id: commit
         uses: stefanzweifel/git-auto-commit-action@v6
         with:

--- a/.github/workflows/sync-headers.yml
+++ b/.github/workflows/sync-headers.yml
@@ -64,15 +64,26 @@ jobs:
       - name: License scan - eigen headers
         uses: fossology/fossology-action@v1
         with:
-          scan_mode: repo
-          scanners: 'nomos ojo copyright keyword'
+          scan_mode: scan-dir
+          scanners: 'nomos ojo'
           report_format: 'SPDX_JSON'
           scan_dir: src/pgm_build_dependencies/eigen/
 
+      - name: List fossology output
+        if: always()
+        run: |
+          echo "=== Current directory contents ==="
+          ls -la
+          echo "=== Looking for result directories ==="
+          find . -name "*result*" -type d
+          echo "=== Looking for output files ==="
+          find . -name "*.json" -o -name "*spdx*" -o -name "*SPDX*"
+
       - name: Upload Scan Results Artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: Fossology scan results
+          name: license-scan-results
           path: results/
 
       - name: build wheel

--- a/.github/workflows/sync-headers.yml
+++ b/.github/workflows/sync-headers.yml
@@ -69,20 +69,18 @@ jobs:
           report_format: 'SPDX_JSON'
           scan_dir: src/pgm_build_dependencies/eigen/
 
-      - name: Upload Scan Results Artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: license-scan-results
-          path: results/
-
       - name: Remove files with non-accepted license
         run: |          
           # Install jq for JSON parsing
           sudo apt-get update && sudo apt-get install -y jq
           
+          echo "=== Looking for SPDX files ==="
+          ls -la
+          find . -name "*.json" -type f
+          
           # Find the SPDX JSON file
-          SPDX_FILE=$(find . -name "*spdx*.json" | head -1)
+          SPDX_FILE=$(find . -name "*spdx*.json" -o -name "sbom*.json" -o -name "*sbom.json"| head -1)
+          
           if [ -z "$SPDX_FILE" ]; then
             echo "No SPDX JSON file found!"
             exit 1
@@ -116,6 +114,13 @@ jobs:
             done
           fi
         continue-on-error: true
+
+      - name: Upload Scan Results Artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: license-scan-results
+          path: results/
 
       - name: build wheel
         run: |

--- a/.github/workflows/sync-headers.yml
+++ b/.github/workflows/sync-headers.yml
@@ -70,6 +70,7 @@ jobs:
           scan_dir: src/pgm_build_dependencies/eigen/
 
       - name: Remove files with non-accepted license
+        if: always()
         run: |          
           # Install jq for JSON parsing
           sudo apt-get update && sudo apt-get install -y jq
@@ -82,8 +83,11 @@ jobs:
           SPDX_FILE=$(find . -name "*spdx*.json" -o -name "sbom*.json" -o -name "*sbom.json"| head -1)
           
           if [ -z "$SPDX_FILE" ]; then
-            echo "No SPDX JSON file found!"
-            exit 1
+            echo "No SPDX JSON file found! Fossology scan may have failed."
+            echo "Available files:"
+            find . -name "*.json" || echo "No JSON files found"
+            echo "Skipping license cleanup step."
+            exit 0
           fi
           echo "Found SPDX file: $SPDX_FILE"
           

--- a/.github/workflows/sync-headers.yml
+++ b/.github/workflows/sync-headers.yml
@@ -70,6 +70,7 @@ jobs:
           scan_dir: src/pgm_build_dependencies/eigen/
 
       - name: Remove files with non-accepted license
+        id: license-cleanup
         if: always()
         run: |          
           # Install jq for JSON parsing
@@ -119,6 +120,16 @@ jobs:
           fi
         continue-on-error: true
 
+      - name: Check license cleanup status
+        if: always()
+        run: |
+          if [ "${{ steps.license-cleanup.outcome }}" = "failure" ]; then
+            echo "WARNING: License cleanup step failed!"
+            echo "Please check the license scan results manually."
+          else
+            echo "License cleanup completed successfully"
+          fi
+
       - name: Upload Scan Results Artifact
         if: always()
         uses: actions/upload-artifact@v4
@@ -127,12 +138,14 @@ jobs:
           path: results/
 
       - name: build wheel
+        if: always()
         run: |
           python -m build --wheel --outdir dist
           ls dist/
           echo "VERSION=v$(date +'%Y.%m.%d')" >> $GITHUB_ENV
 
       - name: Commit and push changes
+        if: always()
         id: commit
         uses: stefanzweifel/git-auto-commit-action@v6
         with:

--- a/.github/workflows/sync-headers.yml
+++ b/.github/workflows/sync-headers.yml
@@ -140,17 +140,6 @@ jobs:
           ls dist/
           echo "VERSION=v$(date +'%Y.%m.%d')" >> $GITHUB_ENV
 
-      - name: Debug workflow trigger
-        run: |
-          echo "Event name: ${{ github.event_name }}"
-          echo "Force publish input: ${{ inputs.force_publish }}"
-          echo "Will commit on schedule or when force_publish is true: ${{ github.event_name == 'schedule' || inputs.force_publish }}"
-
-      - name: Check git status before commit
-        run: |
-          git status
-          git diff --name-only || echo "No differences found"
-
       - name: Commit and push changes
         if: ${{ github.event_name == 'schedule' || inputs.force_publish }}
         id: commit

--- a/.github/workflows/sync-headers.yml
+++ b/.github/workflows/sync-headers.yml
@@ -116,17 +116,9 @@ jobs:
               fi
             done
           fi
-        continue-on-error: true
 
-      - name: Check license cleanup status
-        run: |
-          if [ "${{ steps.license-cleanup.outcome }}" = "failure" ]; then
-            echo "ERROR: License cleanup step failed!"
-            echo "Terminating workflow due to license scanning issues."
-            exit 1
-          else
-            echo "License cleanup completed successfully"
-          fi
+      - name: License cleanup completed
+        run: echo "License cleanup completed successfully"
 
       - name: Upload Scan Results Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/sync-headers.yml
+++ b/.github/workflows/sync-headers.yml
@@ -61,14 +61,13 @@ jobs:
           ls src/pgm_build_dependencies/eigen/
           ls src/pgm_build_dependencies/msgpack_cxx/
 
-      - name: License scan - eigen headers
+      - name: License scan - entire repository
         uses: fossology/fossology-action@v1
         continue-on-error: true
         with:
-          scan_mode: scan-dir
-          scanners: 'nomos ojo'
-          report_format: 'SPDX_JSON'
-          scan_dir: src/pgm_build_dependencies/eigen/
+            scan_mode: repo
+            scanners: 'nomos ojo'
+            report_format: 'SPDX_JSON'
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
@@ -87,11 +86,16 @@ jobs:
           fi
           echo "Found SPDX file: $SPDX_FILE"
           
-          # Get badly licensed files
+          # Get badly licensed files (excluding .git and .github directories)
+          echo "Extracting and deduplicating badly licensed files..."
           BAD_FILES=$(jq -r '
-            .files[] | 
-            select(.licenseInfoInFiles[]? | type == "string" and test("GPL"; "i")) | 
-            .fileName
+            [.files[] | 
+             select(.licenseInfoInFiles[]? | type == "string" and test("GPL"; "i")) | 
+             select(.fileName | test("^\\.git/") | not) |
+             select(.fileName | test("^\\.github/") | not) |
+             .fileName] | 
+            unique | 
+            .[]
           ' "$SPDX_FILE")
           
           if [ -z "$BAD_FILES" ]; then
@@ -102,13 +106,12 @@ jobs:
               if [ -n "$file_name" ]; then
                 echo " - $file_name"
                 
-                # Construct full path and delete
-                full_path="src/pgm_build_dependencies/eigen/$file_name"
-                if [ -f "$full_path" ]; then
-                  rm -f "$full_path"
-                  echo "Deleted: $full_path"
+                if [ -f "$file_name" ]; then
+                  rm -f "$file_name"
+                  echo "Deleted: $file_name"
                 else
-                  echo "File not found: $full_path"
+                  echo "File not found: $file_name"
+                  exit 1
                 fi
               fi
             done
@@ -118,8 +121,9 @@ jobs:
       - name: Check license cleanup status
         run: |
           if [ "${{ steps.license-cleanup.outcome }}" = "failure" ]; then
-            echo "WARNING: License cleanup step failed!"
-            echo "Please check the license scan results manually."
+            echo "ERROR: License cleanup step failed!"
+            echo "Terminating workflow due to license scanning issues."
+            exit 1
           else
             echo "License cleanup completed successfully"
           fi
@@ -141,6 +145,11 @@ jobs:
           echo "Event name: ${{ github.event_name }}"
           echo "Force publish input: ${{ inputs.force_publish }}"
           echo "Will commit on schedule or when force_publish is true: ${{ github.event_name == 'schedule' || inputs.force_publish }}"
+
+      - name: Check git status before commit
+        run: |
+          git status
+          git diff --name-only || echo "No differences found"
 
       - name: Commit and push changes
         if: ${{ github.event_name == 'schedule' || inputs.force_publish }}


### PR DESCRIPTION
In this PR I try to remove the files that aren't compliant with PGM's license from the dependencies, and then to proceed with the building of such dependencies.

The workflow is as follows: Use [`fossology-action`](https://github.com/fossology/fossology-action?tab=readme-ov-file) (which uses [`fossology`](https://github.com/fossology/fossology) engine under the hood - same tooling used by LF), store the licensing results in a `json` file, parse that file using [`jq`](https://github.com/jqlang/jq) to find the files with undesirable license, remove those files, build.