### PR TITLE
Change cron schedule to run on Mondays

### DIFF
--- a/.github/workflows/sync-headers.yml
+++ b/.github/workflows/sync-headers.yml
@@ -17,7 +17,7 @@ on:
         type: boolean
 
   schedule:
-    - cron: "0 2 * * 0" # Runs at 02:00 UTC every Sunday
+    - cron: "0 2 * * 1" # Runs at 02:00 UTC every Monday
 
 jobs:
   sync-headers:


### PR DESCRIPTION
The PGM build dependencies bot has been running for a couple weeks now and has proved to be very useful. However, I'm not a huge fan of the fact that it is scheduled to run on Sundays (I prefer as few notifications as possible during the weekend)
