### PR TITLE
Add local dev support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,4 @@ CLI11 = "pgm_build_dependencies.cli11"
 
 [project.scripts]
 pgm-build-setup-ga-ci = "pgm_build_dependencies.setup_ga_ci:setup_ga_ci"
+pgm-build-setup-path = "pgm_build_dependencies.cmake_prefix_path:cmake_prefix_path"

--- a/src/pgm_build_dependencies/cmake_prefix_path.py
+++ b/src/pgm_build_dependencies/cmake_prefix_path.py
@@ -6,17 +6,12 @@ from importlib.metadata import entry_points
 import os
 
 def cmake_prefix_path():
-    """Output a single CMAKE_PREFIX_PATH usable for CMake (common parent of all cmake.root packages).
-    """
+    """Output CMAKE_PREFIX_PATH for all pgm build dependencies"""
     cmake_roots = entry_points(group="cmake.root")
-
+    
     paths = []
     for ep in cmake_roots:
         loaded = ep.load()
         paths.append(loaded.__path__[0])
-
-    if paths:
-        common_path = os.path.commonpath(paths)
-        print(common_path)
-    else:
-        print("")
+    
+    print(os.pathsep.join(paths))

--- a/src/pgm_build_dependencies/cmake_prefix_path.py
+++ b/src/pgm_build_dependencies/cmake_prefix_path.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+from importlib.metadata import entry_points
+import os
+
+def cmake_prefix_path():
+    """Output a single CMAKE_PREFIX_PATH usable for CMake (common parent of all cmake.root packages).
+    """
+    cmake_roots = entry_points(group="cmake.root")
+
+    paths = []
+    for ep in cmake_roots:
+        loaded = ep.load()
+        paths.append(loaded.__path__[0])
+
+    if paths:
+        common_path = os.path.commonpath(paths)
+        print(common_path)
+    else:
+        print("")


### PR DESCRIPTION
This PR adds support for local development.

If a user wants to install all the PGM's C++ dependencies, then using this repo +  `pgm-build-setup-path` (introduced in this PR), allows them to easily get the path to set their `CMAKE_PREFIX_PATH` easily.

**DO NOT MERGE** until fully tested and reviewed.